### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/.github          export-ignore
+/.gitattributes   export-ignore
+/*.sh             export-ignore
+
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Configure diff output for .php files
+*.php diff=php


### PR DESCRIPTION
To exclude `*.sh` files from any zips downloaded from Github